### PR TITLE
Update version to 15.7.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fess-webapp-multimodal</artifactId>
-	<version>15.6.1-SNAPSHOT</version>
+	<version>15.7.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>fess-webapp-multimodal</name>
 	<scm>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.6.0</version>
+		<version>15.7.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary

Bump version for the 15.7.0 development cycle. Depends on `fess-parent` `15.7.0-SNAPSHOT` which is already available on the Maven snapshot repository.

- Project version: `15.6.x-SNAPSHOT` -> `15.7.0-SNAPSHOT`
- `fess-parent` reference: `15.6.0` -> `15.7.0-SNAPSHOT`

## Test plan

- [ ] CI build passes against `fess-parent:15.7.0-SNAPSHOT`