### PR TITLE
chore: bump parent version to 15.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.7.0-SNAPSHOT</version>
+		<version>15.7.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
Locks onto the released fess-parent 15.7.0.