### PR TITLE
fix(test): add missing JUnit 5 annotations so dormant tests run

### DIFF
--- a/src/test/java/org/codelibs/fess/multimodal/client/CasClientTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/client/CasClientTest.java
@@ -24,10 +24,12 @@ import org.codelibs.curl.CurlException;
 import org.codelibs.fess.multimodal.crawler.extractor.CasExtractorTest;
 import org.codelibs.fess.multimodal.exception.CasAccessException;
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 
 public class CasClientTest extends UnitWebappTestCase {
     static final Logger logger = Logger.getLogger(CasExtractorTest.class.getName());
 
+    @Test
     public void test_encodeImage() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -38,6 +40,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_getImageEmbedding() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -49,6 +52,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_getTextEmbedding() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -60,6 +64,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_init_setsDefaultValues() {
         final CasClient client = new CasClient();
         client.init();
@@ -72,6 +77,7 @@ public class CasClientTest extends UnitWebappTestCase {
         assertEquals("http://localhost:51000", client.clipEndpoint);
     }
 
+    @Test
     public void test_init_readsSystemProperties() {
         try {
             System.setProperty("clip.image.width", "512");
@@ -100,6 +106,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_encodeImage_nullInputStream_throwsException() {
         final CasClient client = new CasClient();
         client.init();
@@ -116,6 +123,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_encodeImage_emptyInputStream_throwsException() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -129,6 +137,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_encodeImage_invalidImageData_throwsException() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -142,6 +151,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_encodeImage_imageTooLarge_throwsException() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -157,6 +167,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_encodeImage_differentAspectRatios() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -168,6 +179,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_getTextEmbedding_emptyString_handlesGracefully() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -180,6 +192,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_getTextEmbedding_longText_handlesGracefully() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -197,6 +210,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_getTextEmbedding_specialCharacters_handlesGracefully() throws Exception {
         final CasClient client = new CasClient();
         client.init();
@@ -209,6 +223,7 @@ public class CasClientTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_sendImage_validBase64_returnsEmbedding() {
         final CasClient client = new CasClient();
         client.init();

--- a/src/test/java/org/codelibs/fess/multimodal/crawler/extractor/CasExtractorTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/crawler/extractor/CasExtractorTest.java
@@ -31,6 +31,7 @@ import org.codelibs.fess.multimodal.client.CasClient;
 import org.codelibs.fess.multimodal.exception.CasAccessException;
 import org.codelibs.fess.multimodal.util.EmbeddingUtil;
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 /**
@@ -62,6 +63,7 @@ public class CasExtractorTest extends UnitWebappTestCase {
         casExtractor.init();
     }
 
+    @Test
     public void test_getTika() {
         final InputStream in = ResourceUtil.getResourceAsStream("images/codelibs_cover.jpeg");
         final ExtractData extractData = casExtractor.getText(in, null);
@@ -74,6 +76,7 @@ public class CasExtractorTest extends UnitWebappTestCase {
         assertEquals(5, embedding.length);
     }
 
+    @Test
     public void test_getText_withValidImage_extractsEmbedding() {
         final InputStream in = ResourceUtil.getResourceAsStream("images/codelibs_cover.jpeg");
         final ExtractData extractData = casExtractor.getText(in, null);
@@ -93,6 +96,7 @@ public class CasExtractorTest extends UnitWebappTestCase {
         assertEquals(5.0f, embedding[4]);
     }
 
+    @Test
     public void test_getText_withParams_passesParams() {
         final InputStream in = ResourceUtil.getResourceAsStream("images/codelibs_cover.jpeg");
         final Map<String, String> params = new HashMap<>();
@@ -107,6 +111,7 @@ public class CasExtractorTest extends UnitWebappTestCase {
         assertEquals(1, values.length);
     }
 
+    @Test
     public void test_getText_withErrorInEmbedding_handlesGracefully() {
         final StandardCrawlerContainer container = new StandardCrawlerContainer();
         container//
@@ -138,6 +143,7 @@ public class CasExtractorTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_getText_withNullInputStream_handlesGracefully() {
         try {
             final ExtractData extractData = casExtractor.getText(null, null);
@@ -148,6 +154,7 @@ public class CasExtractorTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_getText_withEmptyInputStream_handlesGracefully() {
         final InputStream in = new ByteArrayInputStream(new byte[0]);
         try {
@@ -161,11 +168,13 @@ public class CasExtractorTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_getWeight_returnsCorrectValue() {
         final int weight = casExtractor.getWeight();
         assertEquals(10, weight);
     }
 
+    @Test
     public void test_init_initializesClient() {
         final StandardCrawlerContainer container = new StandardCrawlerContainer();
         container//
@@ -185,6 +194,7 @@ public class CasExtractorTest extends UnitWebappTestCase {
         assertNotNull(extractor.client);
     }
 
+    @Test
     public void test_getText_withMultipleImages_processesEach() {
         for (int i = 0; i < 3; i++) {
             final InputStream in = ResourceUtil.getResourceAsStream("images/codelibs_cover.jpeg");

--- a/src/test/java/org/codelibs/fess/multimodal/exception/CasAccessExceptionTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/exception/CasAccessExceptionTest.java
@@ -23,9 +23,11 @@ import java.io.ObjectOutputStream;
 
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 
 public class CasAccessExceptionTest extends UnitWebappTestCase {
 
+    @Test
     public void test_constructorWithMessageAndCause_storesValuesCorrectly() {
         final String message = "Test error message";
         final Exception cause = new IOException("IO error");
@@ -37,6 +39,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertTrue(exception instanceof CrawlerSystemException);
     }
 
+    @Test
     public void test_constructorWithMessageOnly_storesMessageCorrectly() {
         final String message = "Test error message";
 
@@ -47,6 +50,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertTrue(exception instanceof CrawlerSystemException);
     }
 
+    @Test
     public void test_constructorWithNullMessage_acceptsNull() {
         final Exception cause = new IOException("IO error");
 
@@ -56,6 +60,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertEquals(cause, exception.getCause());
     }
 
+    @Test
     public void test_constructorWithEmptyMessage_acceptsEmpty() {
         final String message = "";
         final Exception cause = new IOException("IO error");
@@ -66,6 +71,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertEquals(cause, exception.getCause());
     }
 
+    @Test
     public void test_constructorWithNullCause_acceptsNull() {
         final String message = "Test error message";
 
@@ -75,6 +81,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertNull(exception.getCause());
     }
 
+    @Test
     public void test_constructorWithNullMessageAndCause_acceptsBoth() {
         final CasAccessException exception = new CasAccessException(null, null);
 
@@ -82,6 +89,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertNull(exception.getCause());
     }
 
+    @Test
     public void test_exceptionChaining_preservesCauseCorrectly() {
         final IOException rootCause = new IOException("Root cause");
         final RuntimeException intermediateCause = new RuntimeException("Intermediate", rootCause);
@@ -94,6 +102,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertEquals(rootCause, exception.getCause().getCause());
     }
 
+    @Test
     public void test_stackTrace_includesToStringOfCause() {
         final IOException cause = new IOException("IO error details");
         final String message = "CAS connection failed";
@@ -106,6 +115,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertTrue(stackTrace.contains("IO error details"));
     }
 
+    @Test
     public void test_serialization_roundTripPreservesData() throws Exception {
         final String message = "Serialization test message";
         final IOException cause = new IOException("Serialization cause");
@@ -129,6 +139,7 @@ public class CasAccessExceptionTest extends UnitWebappTestCase {
         assertEquals(original.getCause().getMessage(), deserialized.getCause().getMessage());
     }
 
+    @Test
     public void test_inheritanceHierarchy_extendsCorrectClass() {
         final CasAccessException exception = new CasAccessException("test");
 

--- a/src/test/java/org/codelibs/fess/multimodal/helper/MultiModalSearchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/helper/MultiModalSearchHelperTest.java
@@ -24,6 +24,7 @@ import static org.codelibs.fess.multimodal.MultiModalConstants.DEFAULT_CONTENT_F
 import static org.codelibs.fess.multimodal.MultiModalConstants.MIN_SCORE;
 
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 public class MultiModalSearchHelperTest extends UnitWebappTestCase {
@@ -54,6 +55,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         System.clearProperty(MIN_SCORE);
     }
 
+    @Test
     public void test_load_defaultConfiguration_setsDefaults() {
         // No system properties set
         final String result = helper.load();
@@ -64,6 +66,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertTrue(result.contains("min_score="));
     }
 
+    @Test
     public void test_load_customConfiguration_appliesCustomValues() {
         // Set custom properties
         System.setProperty(CONTENT_FIELD, "custom_vector_field");
@@ -77,6 +80,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertTrue(result.contains("min_score=0.8"));
     }
 
+    @Test
     public void test_load_invalidMinScore_handlesGracefully() {
         System.setProperty(MIN_SCORE, "invalid_number");
 
@@ -86,6 +90,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertTrue(result.contains("min_score="));
     }
 
+    @Test
     public void test_load_emptyMinScore_handlesGracefully() {
         System.setProperty(MIN_SCORE, "");
 
@@ -94,6 +99,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertNull(helper.getMinScore());
     }
 
+    @Test
     public void test_load_whitespaceMinScore_handlesGracefully() {
         System.setProperty(MIN_SCORE, "   ");
 
@@ -108,6 +114,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
     // Note: rewriteQuery tests removed due to ComponentUtil dependency
     // These would test query rewriting logic that requires container initialization
 
+    @Test
     public void test_getMinScore_returnsConfiguredValue() {
         System.setProperty(MIN_SCORE, "0.7");
         helper.load();
@@ -115,6 +122,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertEquals(Float.valueOf(0.7f), helper.getMinScore());
     }
 
+    @Test
     public void test_getVectorField_returnsConfiguredValue() {
         System.setProperty(CONTENT_FIELD, "my_vector_field");
         helper.load();
@@ -122,42 +130,49 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertEquals("my_vector_field", helper.getVectorField());
     }
 
+    @Test
     public void test_rewriteQuery_nullQuery_returnsNull() {
         helper.load();
         final String result = helper.rewriteQuery(null);
         assertNull(result);
     }
 
+    @Test
     public void test_rewriteQuery_emptyQuery_returnsEmpty() {
         helper.load();
         final String result = helper.rewriteQuery("");
         assertEquals("", result);
     }
 
+    @Test
     public void test_rewriteQuery_blankQuery_returnsBlank() {
         helper.load();
         final String result = helper.rewriteQuery("   ");
         assertEquals("   ", result);
     }
 
+    @Test
     public void test_rewriteQuery_singleWord_returnsUnchanged() {
         helper.load();
         final String result = helper.rewriteQuery("test");
         assertEquals("test", result);
     }
 
+    @Test
     public void test_rewriteQuery_queryWithQuotes_returnsUnchanged() {
         helper.load();
         final String result = helper.rewriteQuery("\"test query\"");
         assertEquals("\"test query\"", result);
     }
 
+    @Test
     public void test_rewriteQuery_queryWithoutSpaces_returnsUnchanged() {
         helper.load();
         final String result = helper.rewriteQuery("testquery");
         assertEquals("testquery", result);
     }
 
+    @Test
     public void test_load_trimsVectorField() {
         System.setProperty(CONTENT_FIELD, "  custom_vector  ");
         helper.load();
@@ -165,6 +180,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertEquals("custom_vector", helper.getVectorField());
     }
 
+    @Test
     public void test_load_multipleInvocations_updatesValues() {
         System.setProperty(CONTENT_FIELD, "field1");
         System.setProperty(MIN_SCORE, "0.5");
@@ -181,6 +197,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertEquals(Float.valueOf(0.9f), helper.getMinScore());
     }
 
+    @Test
     public void test_load_zeroMinScore_setsZero() {
         System.setProperty(MIN_SCORE, "0.0");
         helper.load();
@@ -188,6 +205,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertEquals(Float.valueOf(0.0f), helper.getMinScore());
     }
 
+    @Test
     public void test_load_negativeMinScore_setsNegative() {
         System.setProperty(MIN_SCORE, "-0.5");
         helper.load();
@@ -195,6 +213,7 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertEquals(Float.valueOf(-0.5f), helper.getMinScore());
     }
 
+    @Test
     public void test_load_veryLargeMinScore_setsLarge() {
         System.setProperty(MIN_SCORE, "999999.99");
         helper.load();
@@ -202,11 +221,13 @@ public class MultiModalSearchHelperTest extends UnitWebappTestCase {
         assertEquals(Float.valueOf(999999.99f), helper.getMinScore());
     }
 
+    @Test
     public void test_getMinScore_withoutLoad_returnsNull() {
         final MultiModalSearchHelper newHelper = new MultiModalSearchHelper();
         assertNull(newHelper.getMinScore());
     }
 
+    @Test
     public void test_getVectorField_withoutLoad_returnsNull() {
         final MultiModalSearchHelper newHelper = new MultiModalSearchHelper();
         assertNull(newHelper.getVectorField());

--- a/src/test/java/org/codelibs/fess/multimodal/index/query/KNNQueryBuilderTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/index/query/KNNQueryBuilderTest.java
@@ -25,6 +25,7 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 
 public class KNNQueryBuilderTest extends UnitWebappTestCase {
 
@@ -32,6 +33,7 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
     private static final float[] TEST_VECTOR = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
     private static final int TEST_K = 15;
 
+    @Test
     public void test_builder_defaultValues_setsCorrectDefaults() {
         final KNNQueryBuilder.Builder builder = new KNNQueryBuilder.Builder();
         final KNNQueryBuilder query = builder.build();
@@ -46,6 +48,7 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertNull(query.minScore);
     }
 
+    @Test
     public void test_builder_fluentAPI_chainsCorrectly() {
         final BoolQueryBuilder testFilter = QueryBuilders.boolQuery();
 
@@ -67,12 +70,14 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertEquals(Float.valueOf(0.5f), query.minScore);
     }
 
+    @Test
     public void test_builder_field_setsFieldName() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field("my_field").build();
 
         assertEquals("my_field", query.fieldName);
     }
 
+    @Test
     public void test_builder_vector_setsVector() {
         final float[] vector = { 1.0f, 2.0f };
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().vector(vector).build();
@@ -80,12 +85,14 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertSame(vector, query.vector);
     }
 
+    @Test
     public void test_builder_k_setsKValue() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().k(25).build();
 
         assertEquals(25, query.k);
     }
 
+    @Test
     public void test_builder_filter_setsFilter() {
         final BoolQueryBuilder filter = QueryBuilders.boolQuery();
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().filter(filter).build();
@@ -93,24 +100,28 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertSame(filter, query.filter);
     }
 
+    @Test
     public void test_builder_ignoreUnmapped_setsFlag() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().ignoreUnmapped(true).build();
 
         assertTrue(query.ignoreUnmapped);
     }
 
+    @Test
     public void test_builder_maxDistance_setsThreshold() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().maxDistance(0.9f).build();
 
         assertEquals(Float.valueOf(0.9f), query.maxDistance);
     }
 
+    @Test
     public void test_builder_minScore_setsThreshold() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().minScore(0.3f).build();
 
         assertEquals(Float.valueOf(0.3f), query.minScore);
     }
 
+    @Test
     public void test_builder_build_constructsImmutableInstance() {
         final KNNQueryBuilder.Builder builder = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(TEST_VECTOR);
 
@@ -130,6 +141,7 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
     // Note: XContent serialization tests removed due to JsonXContent usage complexity
     // These would test the doXContent method but require proper XContentBuilder setup
 
+    @Test
     public void test_equals_identicalObjects_returnsTrue() {
         final KNNQueryBuilder query1 = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(TEST_VECTOR).k(TEST_K).build();
 
@@ -139,6 +151,7 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertTrue(query2.equals(query1));
     }
 
+    @Test
     public void test_equals_differentFieldName_returnsFalse() {
         final KNNQueryBuilder query1 = new KNNQueryBuilder.Builder().field("field1").vector(TEST_VECTOR).build();
 
@@ -147,6 +160,7 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertFalse(query1.equals(query2));
     }
 
+    @Test
     public void test_equals_differentVector_returnsFalse() {
         final KNNQueryBuilder query1 = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(new float[] { 1.0f, 2.0f }).build();
 
@@ -155,6 +169,7 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertFalse(query1.equals(query2));
     }
 
+    @Test
     public void test_equals_differentK_returnsFalse() {
         final KNNQueryBuilder query1 = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(TEST_VECTOR).k(10).build();
 
@@ -163,18 +178,21 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertFalse(query1.equals(query2));
     }
 
+    @Test
     public void test_equals_nullComparison_returnsFalse() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(TEST_VECTOR).build();
 
         assertFalse(query.equals(null));
     }
 
+    @Test
     public void test_equals_selfComparison_returnsTrue() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(TEST_VECTOR).build();
 
         assertTrue(query.equals(query));
     }
 
+    @Test
     public void test_hashCode_identicalObjects_returnsSameHashCode() {
         final KNNQueryBuilder query1 = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(TEST_VECTOR).k(TEST_K).build();
 
@@ -183,6 +201,7 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertEquals(query1.hashCode(), query2.hashCode());
     }
 
+    @Test
     public void test_hashCode_differentObjects_mayReturnDifferentHashCode() {
         final KNNQueryBuilder query1 = new KNNQueryBuilder.Builder().field("field1").vector(TEST_VECTOR).build();
 
@@ -192,12 +211,14 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertNotSame(query1.hashCode(), query2.hashCode());
     }
 
+    @Test
     public void test_build_nullVector_allowsNull() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(null).build();
 
         assertNull(query.vector);
     }
 
+    @Test
     public void test_build_emptyVector_allowsEmpty() {
         final float[] emptyVector = new float[0];
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field(TEST_FIELD).vector(emptyVector).build();
@@ -206,24 +227,28 @@ public class KNNQueryBuilderTest extends UnitWebappTestCase {
         assertEquals(0, query.vector.length);
     }
 
+    @Test
     public void test_build_negativeK_allowsNegative() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field(TEST_FIELD).k(-1).build();
 
         assertEquals(-1, query.k);
     }
 
+    @Test
     public void test_build_zeroK_allowsZero() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field(TEST_FIELD).k(0).build();
 
         assertEquals(0, query.k);
     }
 
+    @Test
     public void test_getWriteableName_returnsKnn() {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field(TEST_FIELD).build();
 
         assertEquals("knn", query.getWriteableName());
     }
 
+    @Test
     public void test_doToQuery_throwsUnsupportedOperationException() throws IOException {
         final KNNQueryBuilder query = new KNNQueryBuilder.Builder().field(TEST_FIELD).build();
 

--- a/src/test/java/org/codelibs/fess/multimodal/ingest/EmbeddingIngesterTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/ingest/EmbeddingIngesterTest.java
@@ -20,11 +20,13 @@ import java.util.Map;
 
 import org.codelibs.fess.multimodal.util.EmbeddingUtil;
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 
 public class EmbeddingIngesterTest extends UnitWebappTestCase {
 
     private static final String VECTOR_FIELD = "vector_field";
 
+    @Test
     public void test_process() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -50,6 +52,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         assertEquals("P4AAAEAAAABAQAAA", result.get(VECTOR_FIELD));
     }
 
+    @Test
     public void test_process_emptyMap_returnsEmptyMap() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -61,6 +64,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         assertEquals(0, result.size());
     }
 
+    @Test
     public void test_process_withoutVectorField_returnsUnchanged() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -76,6 +80,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         assertEquals(123, result.get("another_field"));
     }
 
+    @Test
     public void test_process_withValidEncodedEmbedding_decodesCorrectly() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -96,6 +101,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_process_withMultipleEncodedValues_usesFirstValue() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -115,6 +121,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         assertEquals(2.0f, decodedArray[1], 0.0001f);
     }
 
+    @Test
     public void test_process_withNonArrayValue_keepsOriginal() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -128,6 +135,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         assertEquals("not_an_array", result.get(VECTOR_FIELD));
     }
 
+    @Test
     public void test_process_withNullVectorField_handlesGracefully() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -142,6 +150,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         assertNull(result.get(VECTOR_FIELD));
     }
 
+    @Test
     public void test_process_withEmptyStringArray_throwsException() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -158,6 +167,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_process_withLargeEmbedding_handlesCorrectly() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -181,6 +191,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_process_withAdditionalFields_preservesOtherFields() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -200,6 +211,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         assertEquals(123, result.get("id"));
     }
 
+    @Test
     public void test_process_multipleInvocations_worksConsistently() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = VECTOR_FIELD;
@@ -219,6 +231,7 @@ public class EmbeddingIngesterTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_process_withDifferentVectorField_usesCorrectField() {
         final EmbeddingIngester ingester = new EmbeddingIngester();
         ingester.vectorField = "custom_vector";

--- a/src/test/java/org/codelibs/fess/multimodal/query/MultiModalPhraseQueryCommandTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/query/MultiModalPhraseQueryCommandTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.multimodal.query;
 
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 public class MultiModalPhraseQueryCommandTest extends UnitWebappTestCase {
@@ -28,6 +29,7 @@ public class MultiModalPhraseQueryCommandTest extends UnitWebappTestCase {
         command = new MultiModalPhraseQueryCommand();
     }
 
+    @Test
     public void test_commandInstantiation() {
         // Test that the command can be instantiated without issues
         assertNotNull(command);

--- a/src/test/java/org/codelibs/fess/multimodal/query/MultiModalQueryBuilderTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/query/MultiModalQueryBuilderTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.multimodal.query;
 
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 public class MultiModalQueryBuilderTest extends UnitWebappTestCase {
@@ -30,6 +31,7 @@ public class MultiModalQueryBuilderTest extends UnitWebappTestCase {
         super.setUp(testInfo);
     }
 
+    @Test
     public void test_builder_defaultValues_setsCorrectDefaults() {
         final MultiModalQueryBuilder.Builder builder = new MultiModalQueryBuilder.Builder();
         final MultiModalQueryBuilder queryBuilder = builder.build();
@@ -40,6 +42,7 @@ public class MultiModalQueryBuilderTest extends UnitWebappTestCase {
         assertNull(queryBuilder.minScore);
     }
 
+    @Test
     public void test_builder_fluentAPI_chainsCorrectly() {
         final MultiModalQueryBuilder queryBuilder =
                 new MultiModalQueryBuilder.Builder().field(TEST_FIELD).query(TEST_QUERY).k(TEST_K).minScore(TEST_MIN_SCORE).build();
@@ -50,30 +53,35 @@ public class MultiModalQueryBuilderTest extends UnitWebappTestCase {
         assertEquals(TEST_MIN_SCORE, queryBuilder.minScore);
     }
 
+    @Test
     public void test_builder_field_setsFieldName() {
         final MultiModalQueryBuilder queryBuilder = new MultiModalQueryBuilder.Builder().field("my_vector_field").build();
 
         assertEquals("my_vector_field", queryBuilder.field);
     }
 
+    @Test
     public void test_builder_query_setsQueryText() {
         final MultiModalQueryBuilder queryBuilder = new MultiModalQueryBuilder.Builder().query("my search query").build();
 
         assertEquals("my search query", queryBuilder.query);
     }
 
+    @Test
     public void test_builder_k_setsKValue() {
         final MultiModalQueryBuilder queryBuilder = new MultiModalQueryBuilder.Builder().k(25).build();
 
         assertEquals(25, queryBuilder.k);
     }
 
+    @Test
     public void test_builder_minScore_setsMinScore() {
         final MultiModalQueryBuilder queryBuilder = new MultiModalQueryBuilder.Builder().minScore(0.9f).build();
 
         assertEquals(Float.valueOf(0.9f), queryBuilder.minScore);
     }
 
+    @Test
     public void test_builder_build_constructsCorrectly() {
         final MultiModalQueryBuilder.Builder builder = new MultiModalQueryBuilder.Builder().field(TEST_FIELD).query(TEST_QUERY);
 
@@ -90,6 +98,7 @@ public class MultiModalQueryBuilderTest extends UnitWebappTestCase {
     // Note: Testing toQueryBuilder() requires CasClient which depends on ComponentUtil
     // These tests focus on the Builder pattern functionality that can be tested in isolation
 
+    @Test
     public void test_builder_multipleBuilds_createsIndependentInstances() {
         final MultiModalQueryBuilder.Builder builder = new MultiModalQueryBuilder.Builder().field(TEST_FIELD).query(TEST_QUERY);
 

--- a/src/test/java/org/codelibs/fess/multimodal/query/MultiModalTermQueryCommandTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/query/MultiModalTermQueryCommandTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.multimodal.query;
 
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 public class MultiModalTermQueryCommandTest extends UnitWebappTestCase {
@@ -28,6 +29,7 @@ public class MultiModalTermQueryCommandTest extends UnitWebappTestCase {
         command = new MultiModalTermQueryCommand();
     }
 
+    @Test
     public void test_commandInstantiation() {
         // Test that the command can be instantiated without issues
         assertNotNull(command);

--- a/src/test/java/org/codelibs/fess/multimodal/rank/fusion/MultiModalSearcherTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/rank/fusion/MultiModalSearcherTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.multimodal.rank.fusion;
 
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 public class MultiModalSearcherTest extends UnitWebappTestCase {
@@ -35,17 +36,20 @@ public class MultiModalSearcherTest extends UnitWebappTestCase {
         super.tearDown(testInfo);
     }
 
+    @Test
     public void test_searcherInstantiation() {
         // Test that the searcher can be instantiated without issues
         assertNotNull(searcher);
         assertTrue(searcher instanceof MultiModalSearcher);
     }
 
+    @Test
     public void test_getContext_withoutSetup_returnsNull() {
         // Without any context setup, should return null gracefully
         assertNull(searcher.getContext());
     }
 
+    @Test
     public void test_closeContext_withoutContext_handlesGracefully() {
         // Should not throw exception when closing non-existent context
         searcher.closeContext();

--- a/src/test/java/org/codelibs/fess/multimodal/util/EmbeddingUtilTest.java
+++ b/src/test/java/org/codelibs/fess/multimodal/util/EmbeddingUtilTest.java
@@ -16,14 +16,17 @@
 package org.codelibs.fess.multimodal.util;
 
 import org.codelibs.fess.multimodal.UnitWebappTestCase;
+import org.junit.jupiter.api.Test;
 
 public class EmbeddingUtilTest extends UnitWebappTestCase {
 
+    @Test
     public void test_encodeFloatArray() {
         final float[] array = { 1.0f, 2.0f, 3.0f };
         assertEquals("P4AAAEAAAABAQAAA", EmbeddingUtil.encodeFloatArray(array));
     }
 
+    @Test
     public void test_decodeFloatArray() {
         final float[] array = EmbeddingUtil.decodeFloatArray("P4AAAEAAAABAQAAA");
         assertEquals(3, array.length);
@@ -32,6 +35,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         assertEquals(3.0f, array[2]);
     }
 
+    @Test
     public void test_roundTripEncoding_preservesAccuracy() {
         final float[] original = { 1.5f, -2.7f, 0.0f, 999.9f, -0.001f };
         final String encoded = EmbeddingUtil.encodeFloatArray(original);
@@ -43,6 +47,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_encodeFloatArray_emptyArray_handlesCorrectly() {
         final float[] emptyArray = new float[0];
         final String encoded = EmbeddingUtil.encodeFloatArray(emptyArray);
@@ -52,6 +57,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         assertEquals(0, decoded.length);
     }
 
+    @Test
     public void test_encodeFloatArray_singleElement_handlesCorrectly() {
         final float[] singleElement = { 42.0f };
         final String encoded = EmbeddingUtil.encodeFloatArray(singleElement);
@@ -61,6 +67,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         assertEquals(42.0f, decoded[0], 0.0001f);
     }
 
+    @Test
     public void test_encodeFloatArray_largeArray_handlesCorrectly() {
         final float[] largeArray = new float[1000];
         for (int i = 0; i < largeArray.length; i++) {
@@ -76,6 +83,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_encodeFloatArray_specialValues_handlesCorrectly() {
         final float[] specialValues =
                 { Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN, Float.MAX_VALUE, Float.MIN_VALUE, -0.0f, 0.0f };
@@ -93,6 +101,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         assertEquals(0.0f, decoded[6]);
     }
 
+    @Test
     public void test_encodeFloatArray_nullArray_throwsException() {
         try {
             EmbeddingUtil.encodeFloatArray(null);
@@ -102,6 +111,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_decodeFloatArray_nullString_throwsException() {
         try {
             EmbeddingUtil.decodeFloatArray(null);
@@ -111,6 +121,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_decodeFloatArray_emptyString_returnsEmptyArray() {
         final float[] result = EmbeddingUtil.decodeFloatArray("");
 
@@ -119,6 +130,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         assertEquals(0, result.length);
     }
 
+    @Test
     public void test_decodeFloatArray_invalidBase64_throwsException() {
         try {
             EmbeddingUtil.decodeFloatArray("invalid_base64!");
@@ -128,6 +140,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_decodeFloatArray_malformedData_handlesGracefully() {
         // Valid base64 but not divisible by 4 bytes (float size)
         // "Hello" in base64 decodes to 5 bytes
@@ -139,6 +152,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         // The actual float value depends on how "Hell" bytes are interpreted as float
     }
 
+    @Test
     public void test_encoding_consistency_multipleRuns() {
         final float[] testArray = { 1.1f, 2.2f, 3.3f, 4.4f, 5.5f };
 
@@ -160,6 +174,7 @@ public class EmbeddingUtilTest extends UnitWebappTestCase {
         assertArrayEquals(testArray, decoded3);
     }
 
+    @Test
     public void test_performance_largeArrays() {
         // Test with progressively larger arrays to ensure reasonable performance
         final int[] sizes = { 100, 512, 1024, 2048 };


### PR DESCRIPTION
## Summary

Several test classes in this plugin extend the utflute JUnit 5 (Jupiter) base class `UnitWebappTestCase` (which extends `PlainTestCase`), but their `test_*` methods were missing the `@Test` annotation. Under JUnit 5, Surefire only discovers and runs methods annotated with `@Test`, so these test classes were silently **skipped** rather than executed.

This PR adds `@Test` (and the `org.junit.jupiter.api.Test` import) to every no-argument `void test_*` method across the affected test classes, activating **116 previously dormant tests**.

## Changes

- Added `@Test` to 116 test methods across 11 test classes.
- Added `import org.junit.jupiter.api.Test;` where missing.

## Notes

- Private helper methods (e.g. `assertArrayEquals`, `clearSystemProperties`) and `setUp`/`tearDown` overrides were intentionally **not** annotated.
- `setUp(TestInfo)` / `tearDown(TestInfo)` overrides are left without `@BeforeEach` / `@AfterEach` on purpose: the utflute base already declares those annotations on `final` framework-entry methods that delegate to these overridable hooks, so re-annotating would invoke them twice.

## Verification

`mvn test` (offline):

```
Tests run: 116, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

All newly activated tests run and pass.